### PR TITLE
Support multiple doctypes

### DIFF
--- a/Src/Our.Umbraco.NestedContent/Bootstrap.cs
+++ b/Src/Our.Umbraco.NestedContent/Bootstrap.cs
@@ -17,9 +17,6 @@ namespace Our.Umbraco.NestedContent
             foreach (var dataType in e.SavedEntities)
             {
                 ApplicationContext.Current.ApplicationCache.RuntimeCache.ClearCacheItem(
-                    string.Concat("Our.Umbraco.NestedContent.GetContentTypeAliasByGuid_", dataType.Key));
-
-                ApplicationContext.Current.ApplicationCache.RuntimeCache.ClearCacheItem(
                     string.Concat("Our.Umbraco.NestedContent.GetPreValuesCollectionByDataTypeId_", dataType.Id));
             }
         }

--- a/Src/Our.Umbraco.NestedContent/Converters/NestedContentValueConverter.cs
+++ b/Src/Our.Umbraco.NestedContent/Converters/NestedContentValueConverter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Our.Umbraco.NestedContent.Extensions;
 using Our.Umbraco.NestedContent.Helpers;
 using Our.Umbraco.NestedContent.Models;
 using Our.Umbraco.NestedContent.PropertyEditors;
@@ -40,11 +41,18 @@ namespace Our.Umbraco.NestedContent.Converters
                         var rawValue = JsonConvert.DeserializeObject<List<object>>(source.ToString());
                         var processedValue = new List<IPublishedContent>();
 
-                        var preValue = NestedContentHelper.GetPreValuesDictionaryByDataTypeId(propertyType.DataTypeId);
+	                    var preValueCollection = NestedContentHelper.GetPreValuesCollectionByDataTypeId(propertyType.DataTypeId);
+						var preValueDictionary = preValueCollection.AsPreValueDictionary();
 
                         for (var i = 0; i < rawValue.Count; i++)
                         {
                             var o = (JObject)rawValue[i];
+
+                            // convert from old style (v.0.1.1) data format if necessary
+                            // - please note: This call has virtually no impact on rendering performance for new style (>v0.1.1).
+                            //                Even so, this should be removed eventually, when it's safe to assume that there is
+                            //                no longer any need for conversion.
+                            NestedContentHelper.ConvertItemValueFromV011(o, propertyType.DataTypeId, ref preValueCollection);
 
                             var contentTypeAlias = NestedContentHelper.GetContentTypeAliasFromItem(o);
                             if(string.IsNullOrEmpty(contentTypeAlias))
@@ -81,8 +89,8 @@ namespace Our.Umbraco.NestedContent.Converters
 
                         // Detect min/max items == 1 and just return a single IPublishedContent
                         int minItems, maxItems;
-                        if (preValue.ContainsKey("minItems") && int.TryParse(preValue["minItems"], out minItems) && minItems == 1
-                            && preValue.ContainsKey("maxItems") && int.TryParse(preValue["maxItems"], out maxItems) && maxItems == 1)
+                        if (preValueDictionary.ContainsKey("minItems") && int.TryParse(preValueDictionary["minItems"], out minItems) && minItems == 1
+                            && preValueDictionary.ContainsKey("maxItems") && int.TryParse(preValueDictionary["maxItems"], out maxItems) && maxItems == 1)
                         {
                             return processedValue.FirstOrDefault();
                         }

--- a/Src/Our.Umbraco.NestedContent/Converters/NestedContentValueConverter.cs
+++ b/Src/Our.Umbraco.NestedContent/Converters/NestedContentValueConverter.cs
@@ -41,18 +41,23 @@ namespace Our.Umbraco.NestedContent.Converters
                         var processedValue = new List<IPublishedContent>();
 
                         var preValue = NestedContentHelper.GetPreValuesDictionaryByDataTypeId(propertyType.DataTypeId);
-                        var contentType = NestedContentHelper.GetContentTypeFromPreValue(propertyType.DataTypeId);
-                        if (contentType == null)
-                            return null;
-
-                        var publishedContentType = PublishedContentType.Get(PublishedItemType.Content, contentType.Alias);
-                        if (publishedContentType == null)
-                            return null;
 
                         for (var i = 0; i < rawValue.Count; i++)
                         {
-                            var o = rawValue[i];
-                            var propValues = ((JObject)o).ToObject<Dictionary<string, object>>();
+                            var o = (JObject)rawValue[i];
+
+                            var contentTypeAlias = NestedContentHelper.GetContentTypeAliasFromItem(o);
+                            if(string.IsNullOrEmpty(contentTypeAlias))
+                            {
+                                continue;
+                            }
+                            var publishedContentType = PublishedContentType.Get(PublishedItemType.Content, contentTypeAlias);
+                            if(publishedContentType == null)
+                            {
+                                continue;
+                            }
+
+                            var propValues = o.ToObject<Dictionary<string, object>>();
                             var properties = new List<IPublishedProperty>();
 
                             foreach (var jProp in propValues)

--- a/Src/Our.Umbraco.NestedContent/Extensions/ContentTypeServiceExtensions.cs
+++ b/Src/Our.Umbraco.NestedContent/Extensions/ContentTypeServiceExtensions.cs
@@ -6,12 +6,6 @@ namespace Our.Umbraco.NestedContent.Extensions
 {
     internal static class ContentTypeServiceExtensions
     {
-        public static string GetAliasByGuid(this IContentTypeService contentTypeService, Guid id)
-        {
-            return (string)ApplicationContext.Current.ApplicationCache.RuntimeCache.GetCacheItem(
-                string.Concat("Our.Umbraco.NestedContent.GetContentTypeAliasByGuid_", id),
-                () => ApplicationContext.Current.DatabaseContext.Database
-                    .ExecuteScalar<string>("SELECT [cmsContentType].[alias] FROM [cmsContentType] INNER JOIN [umbracoNode] ON [cmsContentType].[nodeId] = [umbracoNode].[id] WHERE [umbracoNode].[uniqueID] = @0", id));
-        }
+        // implementation obsolete as of PR #4 - empty class left for future expansion
     }
 }

--- a/Src/Our.Umbraco.NestedContent/Helpers/NestedContentHelper.cs
+++ b/Src/Our.Umbraco.NestedContent/Helpers/NestedContentHelper.cs
@@ -27,7 +27,7 @@ namespace Our.Umbraco.NestedContent.Helpers
 
         public static string GetContentTypeAliasFromItem(JObject item)
         {
-            var contentTypeAliasProperty = item["contentTypeAlias"];
+            var contentTypeAliasProperty = item["ncContentTypeAlias"];
             if(contentTypeAliasProperty == null)
             {
                 return null;

--- a/Src/Our.Umbraco.NestedContent/Helpers/NestedContentHelper.cs
+++ b/Src/Our.Umbraco.NestedContent/Helpers/NestedContentHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Linq;
+using Newtonsoft.Json.Linq;
 using Our.Umbraco.NestedContent.Extensions;
 using Umbraco.Core;
 using Umbraco.Core.Models;
@@ -24,28 +25,24 @@ namespace Our.Umbraco.NestedContent.Helpers
             return GetPreValuesCollectionByDataTypeId(dtdId).AsPreValueDictionary();
         }
 
-        public static IContentType GetContentTypeFromPreValue(int dtdId)
+        public static string GetContentTypeAliasFromItem(JObject item)
         {
-            var preValueCollection = GetPreValuesCollectionByDataTypeId(dtdId);
-
-            return GetContentTypeFromPreValue(preValueCollection);
+            var contentTypeAliasProperty = item["contentTypeAlias"];
+            if(contentTypeAliasProperty == null)
+            {
+                return null;
+            }
+            return contentTypeAliasProperty.ToObject<string>();
         }
 
-        public static IContentType GetContentTypeFromPreValue(PreValueCollection preValues)
+        public static IContentType GetContentTypeFromItem(JObject item)
         {
-            var preValuesDict = preValues.AsPreValueDictionary();
-
-            Guid contentTypeGuid;
-            if (!preValuesDict.ContainsKey("docTypeGuid") || !Guid.TryParse(preValuesDict["docTypeGuid"], out contentTypeGuid))
+            var contentTypeAlias = GetContentTypeAliasFromItem(item);
+            if(string.IsNullOrEmpty(contentTypeAlias))
+            {
                 return null;
-
-            var contentTypeAlias = ApplicationContext.Current.Services.ContentTypeService.GetAliasByGuid(Guid.Parse(preValuesDict["docTypeGuid"]));
-            var contentType = ApplicationContext.Current.Services.ContentTypeService.GetContentType(contentTypeAlias);
-
-            if (contentType == null || contentType.PropertyTypes == null)
-                return null;
-
-            return contentType;
+            }
+            return ApplicationContext.Current.Services.ContentTypeService.GetContentType(contentTypeAlias);
         }
     }
 }

--- a/Src/Our.Umbraco.NestedContent/Helpers/NestedContentHelper.cs
+++ b/Src/Our.Umbraco.NestedContent/Helpers/NestedContentHelper.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 using Our.Umbraco.NestedContent.Extensions;
+using Our.Umbraco.NestedContent.PropertyEditors;
 using Umbraco.Core;
 using Umbraco.Core.Models;
 using System.Collections.Generic;
@@ -20,14 +21,9 @@ namespace Our.Umbraco.NestedContent.Helpers
             return preValueCollection;
         }
 
-        public static IDictionary<string, string> GetPreValuesDictionaryByDataTypeId(int dtdId)
-        {
-            return GetPreValuesCollectionByDataTypeId(dtdId).AsPreValueDictionary();
-        }
-
         public static string GetContentTypeAliasFromItem(JObject item)
         {
-            var contentTypeAliasProperty = item["ncContentTypeAlias"];
+            var contentTypeAliasProperty = item[NestedContentPropertyEditor.ContentTypeAliasPropertyKey];
             if(contentTypeAliasProperty == null)
             {
                 return null;
@@ -44,5 +40,78 @@ namespace Our.Umbraco.NestedContent.Helpers
             }
             return ApplicationContext.Current.Services.ContentTypeService.GetContentType(contentTypeAlias);
         }
-    }
+
+        #region Conversion from v0.1.1 data formats
+
+        public static void ConvertItemValueFromV011(JObject item, int dtdId, ref PreValueCollection preValues)
+        {
+            var contentTypeAlias = GetContentTypeAliasFromItem(item);
+            if(contentTypeAlias != null)
+            {
+                // the item is already in >v0.1.1 format
+                return;
+            }
+            // old style (v0.1.1) data, let's attempt a conversion
+            // - get the prevalues (if they're not loaded already)
+            preValues = preValues ?? GetPreValuesCollectionByDataTypeId(dtdId);
+            // - convert the prevalues (if necessary)
+            ConvertPreValueCollectionFromV011(preValues);
+            // - get the content types prevalue as JArray
+            var preValuesAsDictionary = preValues.AsPreValueDictionary();
+            if(!preValuesAsDictionary.ContainsKey(ContentTypesPreValueKey) || string.IsNullOrEmpty(preValuesAsDictionary[ContentTypesPreValueKey]) != false)
+            {
+                return;
+            }
+            var preValueContentTypes = JArray.Parse(preValuesAsDictionary[ContentTypesPreValueKey]);
+            if(preValueContentTypes.Any())
+            {
+                // the only thing we can really do is assume that the item is the first available content type 
+                item[NestedContentPropertyEditor.ContentTypeAliasPropertyKey] = preValueContentTypes.First().Value<string>("ncAlias");
+            }
+        }
+
+        public static void ConvertPreValueCollectionFromV011(PreValueCollection preValueCollection)
+        {
+            if(preValueCollection == null)
+            {
+                return;
+            }
+            var persistedPreValuesAsDictionary = preValueCollection.AsPreValueDictionary();
+            // do we have a "docTypeGuid" prevalue and no "contentTypes" prevalue?
+            if(persistedPreValuesAsDictionary.ContainsKey("docTypeGuid") == false || persistedPreValuesAsDictionary.ContainsKey(ContentTypesPreValueKey))
+            {
+                // the prevalues are already in >v0.1.1 format
+                return;
+            }
+            // attempt to parse the doc type guid
+            Guid guid;
+            if(Guid.TryParse(persistedPreValuesAsDictionary["docTypeGuid"], out guid) == false)
+            {
+                // this shouldn't happen... but just in case.
+                return;
+            }
+            // find the content type
+            var contentType = ApplicationContext.Current.Services.ContentTypeService.GetAllContentTypes().FirstOrDefault(c => c.Key == guid);
+            if(contentType == null)
+            {
+                return;
+            }
+
+            // add a prevalue in the format expected by the new (>0.1.1) content type picker/configurator
+            preValueCollection.PreValuesAsDictionary[ContentTypesPreValueKey] = new PreValue(
+                string.Format(@"[{{""ncAlias"": ""{0}"", ""ncTabAlias"": ""{1}"", ""nameTemplate"": ""{2}"", }}]",
+                    contentType.Alias,
+                    persistedPreValuesAsDictionary["tabAlias"],
+                    persistedPreValuesAsDictionary["nameTemplate"]
+                    )
+                );
+        }
+
+        private static string ContentTypesPreValueKey
+        {
+            get { return NestedContentPropertyEditor.NestedContentPreValueEditor.ContentTypesPreValueKey; }
+        }
+
+        #endregion
+	}
 }

--- a/Src/Our.Umbraco.NestedContent/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/Src/Our.Umbraco.NestedContent/PropertyEditors/NestedContentPropertyEditor.cs
@@ -32,7 +32,7 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
             // Setup default values
             _defaultPreValues = new Dictionary<string, object>
             {
-                {"docTypeGuid", ""},
+                {"docTypeGuids", "[]"},
                 {"minItems", 0},
                 {"maxItems", 0},
                 {"confirmDeletes", 1}
@@ -48,8 +48,8 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
 
         internal class NestedContentPreValueEditor : PreValueEditor
         {
-            [PreValueField("docTypeGuid", "Doc Type", "/App_Plugins/NestedContent/Views/nestedcontent.doctypepicker.html", Description = "Select the doc type to use as the data blueprint.")]
-            public string DocTypeGuid { get; set; }
+            [PreValueField("docTypeGuids", "Doc Types", "/App_Plugins/NestedContent/Views/nestedcontent.doctypepicker.html", Description = "Select the doc types to use as the data blueprint.")]
+            public string[] DocTypeGuids { get; set; }
 
             [PreValueField("tabAlias", "Tab", "textstring", Description = "Enter the alias of the tab whos properties should be displayed. If left blank, the first tab on the doc type will be used.")]
             public string TabAlias { get; set; }
@@ -119,15 +119,18 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
                 if (value == null)
                     return string.Empty;
 
-                var contentType = NestedContentHelper.GetContentTypeFromPreValue(propertyType.DataTypeDefinitionId);
-                if (contentType == null)
-                    return string.Empty;
-
                 // Process value
                 for (var i = 0; i < value.Count; i++)
                 {
                     var o = value[i];
                     var propValues = ((JObject)o);
+
+                    var contentType = NestedContentHelper.GetContentTypeFromItem(propValues);
+                    if(contentType == null)
+                    {
+                        continue;
+                    }
+
                     var propValueKeys = propValues.Properties().Select(x => x.Name).ToArray();
 
                     foreach (var propKey in propValueKeys)
@@ -135,7 +138,7 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
                         var propType = contentType.PropertyTypes.FirstOrDefault(x => x.Alias == propKey);
                         if (propType == null)
                         {
-                            if (propKey != "name")
+                            if(IsSystemPropertyKey(propKey) == false)
                             {
                                 // Property missing so just delete the value
                                 propValues[propKey] = null;
@@ -177,15 +180,18 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
                 if (value == null)
                     return string.Empty;
 
-                var contentType = NestedContentHelper.GetContentTypeFromPreValue(propertyType.DataTypeDefinitionId);
-                if (contentType == null)
-                    return string.Empty;
-
                 // Process value
                 for (var i = 0; i < value.Count; i++)
                 {
                     var o = value[i];
                     var propValues = ((JObject)o);
+
+                    var contentType = NestedContentHelper.GetContentTypeFromItem(propValues);
+                    if(contentType == null)
+                    {
+                        continue;
+                    }
+
                     var propValueKeys = propValues.Properties().Select(x => x.Name).ToArray();
 
                     foreach (var propKey in propValueKeys)
@@ -193,7 +199,7 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
                         var propType = contentType.PropertyTypes.FirstOrDefault(x => x.Alias == propKey);
                         if (propType == null)
                         {
-                            if (propKey != "name")
+                            if(IsSystemPropertyKey(propKey) == false)
                             {
                                 // Property missing so just delete the value
                                 propValues[propKey] = null;
@@ -238,15 +244,18 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
                 if (value == null)
                     return string.Empty;
 
-                var contentType = NestedContentHelper.GetContentTypeFromPreValue(editorValue.PreValues);
-                if (contentType == null)
-                    return string.Empty;
-
                 // Process value
                 for (var i = 0; i < value.Count; i++)
                 {
                     var o = value[i];
                     var propValues = ((JObject)o);
+
+                    var contentType = NestedContentHelper.GetContentTypeFromItem(propValues);
+                    if(contentType == null)
+                    {
+                        continue;
+                    }
+
                     var propValueKeys = propValues.Properties().Select(x => x.Name).ToArray();
 
                     foreach (var propKey in propValueKeys)
@@ -254,7 +263,7 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
                         var propType = contentType.PropertyTypes.FirstOrDefault(x => x.Alias == propKey);
                         if (propType == null)
                         {
-                            if (propKey != "name")
+                            if(IsSystemPropertyKey(propKey) == false)
                             {
                                 // Property missing so just delete the value
                                 propValues[propKey] = null;
@@ -298,14 +307,17 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
                 if (value == null)
                     yield break;
 
-                var contentType = NestedContentHelper.GetContentTypeFromPreValue(preValues);
-                if (contentType == null)
-                    yield break;
-
                 for (var i = 0; i < value.Count; i++)
                 {
                     var o = value[i];
                     var propValues = ((JObject)o);
+
+                    var contentType = NestedContentHelper.GetContentTypeFromItem(propValues);
+                    if(contentType == null)
+                    {
+                        continue;
+                    }
+
                     var propValueKeys = propValues.Properties().Select(x => x.Name).ToArray();
 
                     foreach (var propKey in propValueKeys)
@@ -349,5 +361,10 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
         }
 
         #endregion
-    }
+
+        private static bool IsSystemPropertyKey(string propKey)
+        {
+            return propKey == "name" || propKey == "contentTypeAlias";
+        }
+	}
 }

--- a/Src/Our.Umbraco.NestedContent/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/Src/Our.Umbraco.NestedContent/PropertyEditors/NestedContentPropertyEditor.cs
@@ -51,12 +51,6 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
             [PreValueField("contentTypes", "Doc Types", "/App_Plugins/NestedContent/Views/nestedcontent.doctypepicker.html", Description = "Select the doc types to use as the data blueprint.")]
             public string[] ContentTypes { get; set; }
 
-            [PreValueField("tabAlias", "Tab", "textstring", Description = "Enter the alias of the tab whos properties should be displayed. If left blank, the first tab on the doc type will be used.")]
-            public string TabAlias { get; set; }
-
-            [PreValueField("nameTemplate", "Name Template", "textstring", Description = "Enter an angular expression to evaluate against each item for its name.")]
-            public string NameTemplate { get; set; }
-
             [PreValueField("minItems", "Min Items", "number", Description = "Set the minimum number of items allowed.")]
             public string MinItems { get; set; }
 
@@ -364,7 +358,7 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
 
         private static bool IsSystemPropertyKey(string propKey)
         {
-            return propKey == "name" || propKey == "contentTypeAlias";
+            return propKey == "name" || propKey == "ncContentTypeAlias";
         }
 	}
 }

--- a/Src/Our.Umbraco.NestedContent/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/Src/Our.Umbraco.NestedContent/PropertyEditors/NestedContentPropertyEditor.cs
@@ -36,7 +36,7 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
             // Setup default values
             _defaultPreValues = new Dictionary<string, object>
             {
-                {NestedContentPreValueEditor.ContentTypesPreValueKey, "[]"},
+                {NestedContentPreValueEditor.ContentTypesPreValueKey, ""},
                 {"minItems", 0},
                 {"maxItems", 0},
                 {"confirmDeletes", 1}

--- a/Src/Our.Umbraco.NestedContent/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/Src/Our.Umbraco.NestedContent/PropertyEditors/NestedContentPropertyEditor.cs
@@ -32,7 +32,7 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
             // Setup default values
             _defaultPreValues = new Dictionary<string, object>
             {
-                {"docTypeGuids", "[]"},
+                {"contentTypes", "[]"},
                 {"minItems", 0},
                 {"maxItems", 0},
                 {"confirmDeletes", 1}
@@ -48,8 +48,8 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
 
         internal class NestedContentPreValueEditor : PreValueEditor
         {
-            [PreValueField("docTypeGuids", "Doc Types", "/App_Plugins/NestedContent/Views/nestedcontent.doctypepicker.html", Description = "Select the doc types to use as the data blueprint.")]
-            public string[] DocTypeGuids { get; set; }
+            [PreValueField("contentTypes", "Doc Types", "/App_Plugins/NestedContent/Views/nestedcontent.doctypepicker.html", Description = "Select the doc types to use as the data blueprint.")]
+            public string[] ContentTypes { get; set; }
 
             [PreValueField("tabAlias", "Tab", "textstring", Description = "Enter the alias of the tab whos properties should be displayed. If left blank, the first tab on the doc type will be used.")]
             public string TabAlias { get; set; }

--- a/Src/Our.Umbraco.NestedContent/Web/Controllers/NestedContentApiController.cs
+++ b/Src/Our.Umbraco.NestedContent/Web/Controllers/NestedContentApiController.cs
@@ -12,11 +12,18 @@ namespace Our.Umbraco.NestedContent.Web.Controllers
     public class NestedContentApiController : UmbracoAuthorizedJsonController
     {
         [System.Web.Http.HttpGet]
-        public object GetContentTypeAliasByGuid([ModelBinder] Guid guid)
+        public object GetContentTypeAliasesByGuid(string guids)
         {
+            if (string.IsNullOrWhiteSpace(guids)) 
+            {
+                return new 
+                {
+                    aliases = new string[]{}
+                };
+            }
             return new
             {
-                alias = Services.ContentTypeService.GetAliasByGuid(guid)
+                aliases = guids.Split(',').Select(g => Services.ContentTypeService.GetAliasByGuid(Guid.Parse(g))).Where(a => string.IsNullOrEmpty(a) == false).ToArray()
             };
         }
 

--- a/Src/Our.Umbraco.NestedContent/Web/Controllers/NestedContentApiController.cs
+++ b/Src/Our.Umbraco.NestedContent/Web/Controllers/NestedContentApiController.cs
@@ -12,22 +12,6 @@ namespace Our.Umbraco.NestedContent.Web.Controllers
     public class NestedContentApiController : UmbracoAuthorizedJsonController
     {
         [System.Web.Http.HttpGet]
-        public object GetContentTypeAliasesByGuid(string guids)
-        {
-            if (string.IsNullOrWhiteSpace(guids)) 
-            {
-                return new 
-                {
-                    aliases = new string[]{}
-                };
-            }
-            return new
-            {
-                aliases = guids.Split(',').Select(g => Services.ContentTypeService.GetAliasByGuid(Guid.Parse(g))).Where(a => string.IsNullOrEmpty(a) == false).ToArray()
-            };
-        }
-
-        [System.Web.Http.HttpGet]
         public IEnumerable<object> GetContentTypes()
         {
             return Services.ContentTypeService.GetAllContentTypes()

--- a/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Css/nestedcontent.css
+++ b/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Css/nestedcontent.css
@@ -127,3 +127,8 @@
     background: #f8f8f8;
     border-radius: 15px;
 }
+
+.nested-content__doctypepicker table input, .nested-content__doctypepicker table select {
+  width: 100%;
+  padding-right: 0;
+}

--- a/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Css/nestedcontent.css
+++ b/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Css/nestedcontent.css
@@ -129,6 +129,10 @@
 }
 
 .nested-content__doctypepicker table input, .nested-content__doctypepicker table select {
-  width: 100%;
-  padding-right: 0;
+    width: 100%;
+    padding-right: 0;
+}
+
+.nested-content__doctypepicker table td.icon-navigation {
+    vertical-align: middle;
 }

--- a/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Css/nestedcontent.css
+++ b/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Css/nestedcontent.css
@@ -133,6 +133,15 @@
     padding-right: 0;
 }
 
-.nested-content__doctypepicker table td.icon-navigation {
+.nested-content__doctypepicker table td.icon-navigation, .nested-content__doctypepicker i.nested-content__help-icon {
     vertical-align: middle;
+    color: #CCC;
+}
+
+.nested-content__doctypepicker table td.icon-navigation:hover, .nested-content__doctypepicker i.nested-content__help-icon:hover {
+    color: #343434;
+}
+
+.nested-content__doctypepicker i.nested-content__help-icon {
+    margin-left: 10px;
 }

--- a/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
+++ b/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
@@ -70,10 +70,15 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
             // this could be used for future limiting on node types
             $scope.overlayMenu.scaffolds = [];
             _.each($scope.scaffolds, function (scaffold) {
+                var icon = scaffold.icon;
+                // workaround for when no icon is chosen for a doctype
+                if (icon == ".sprTreeFolder") {
+                    icon = "icon-folder";
+                }
                 $scope.overlayMenu.scaffolds.push({
                     alias: scaffold.contentTypeAlias,
                     name: scaffold.contentTypeName,
-                    icon: scaffold.icon
+                    icon: icon
                 });
             });
 

--- a/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
+++ b/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
@@ -41,10 +41,11 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
 
     "$scope",
     "$interpolate",
+    "$filter",
     "contentResource",
     "Our.Umbraco.NestedContent.Resources.NestedContentResources",
 
-    function ($scope, $interpolate, contentResource, ncResources) {
+    function ($scope, $interpolate, $filter, contentResource, ncResources) {
 
         //$scope.model.config.contentTypes;
         //$scope.model.config.minItems;
@@ -240,6 +241,16 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
         var initIfAllScaffoldsHaveLoaded = function() {
             // Initialize when all scaffolds have loaded
             if ($scope.model.config.contentTypes.length == scaffoldsLoaded) {
+                // Because we're loading the scaffolds async one at a time, we need to 
+                // sort them explicitly according to the sort order defined by the data type.
+                var contentTypeAliases = [];
+                _.each($scope.model.config.contentTypes, function(contentType) {
+                    contentTypeAliases.push(contentType.ncAlias);
+                });
+                $scope.scaffolds = $filter('orderBy')($scope.scaffolds, function (s) {
+                    return contentTypeAliases.indexOf(s.contentTypeAlias);
+                });
+
                 // Convert stored nodes
                 if ($scope.model.value) {
                     for (var i = 0; i < $scope.model.value.length; i++) {

--- a/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
+++ b/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
@@ -88,7 +88,7 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
             $scope.closeNodeTypePicker();
         };
 
-        $scope.openNodeTypePicker = function () {
+        $scope.openNodeTypePicker = function (event) {
             if ($scope.nodes.length >= $scope.maxItems) {
                 return;
             }

--- a/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.resources.js
+++ b/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.resources.js
@@ -1,13 +1,6 @@
 ﻿angular.module('umbraco.resources').factory('Our.Umbraco.NestedContent.Resources.NestedContentResources',
     function ($q, $http, umbRequestHelper) {
         return {
-            getContentTypeAliasesByGuid: function (guids) {
-                var url = "/umbraco/backoffice/NestedContent/NestedContentApi/GetContentTypeAliasesByGuid?guids=" + guids;
-                return umbRequestHelper.resourcePromise(
-                    $http.get(url),
-                    'Failed to retrieve datatype alias by guid'
-                );
-            },
             getContentTypes: function () {
                 var url = "/umbraco/backoffice/NestedContent/NestedContentApi/GetContentTypes";
                 return umbRequestHelper.resourcePromise(

--- a/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.resources.js
+++ b/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.resources.js
@@ -1,8 +1,8 @@
 ﻿angular.module('umbraco.resources').factory('Our.Umbraco.NestedContent.Resources.NestedContentResources',
     function ($q, $http, umbRequestHelper) {
         return {
-            getContentTypeAliasByGuid: function (guid) {
-                var url = "/umbraco/backoffice/NestedContent/NestedContentApi/GetContentTypeAliasByGuid?guid=" + guid;
+            getContentTypeAliasesByGuid: function (guids) {
+                var url = "/umbraco/backoffice/NestedContent/NestedContentApi/GetContentTypeAliasesByGuid?guids=" + guids;
                 return umbRequestHelper.resourcePromise(
                     $http.get(url),
                     'Failed to retrieve datatype alias by guid'

--- a/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.doctypepicker.html
+++ b/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.doctypepicker.html
@@ -3,6 +3,7 @@
         <table class="table table-striped">
             <thead>
                 <tr>
+                    <th/>
                     <th>
                         Document type
                     </th>
@@ -15,15 +16,17 @@
                     <th />
                 </tr>
             </thead>
-            <tbody>
+            <tbody ui-sortable="sortableOptions" ng-model="model.value">
                 <tr ng-repeat="config in model.value">
+                    <td class="icon icon-navigation">
+                    </td>
                     <td>
                         <select id="{{model.alias}}_select"
                                 ng-options="dt.alias as dt.name for dt in model.docTypes | orderBy: 'name'"
-                                ng-model="config.alias"></select>
+                                ng-model="config.ncAlias" required></select>
                     </td>
                     <td>
-                        <input type="text" ng-model="config.tabAlias" />
+                        <input type="text" ng-model="config.ncTabAlias" />
                     </td>
                     <td>
                         <input type="text" ng-model="config.nameTemplate" />
@@ -36,15 +39,15 @@
         </table>
         <a class="btn" ng-click="add()">Add</a>
     </div>
-    <br />
+    <br/>
     <div class="nested-content__help-text ">
         <p>
-            <b>Tab:</b><br />
-            Enter the alias of the tab who's properties should be displayed. If left blank, the first tab on the doc type will be used.
+            <b>Tab:</b><br/>
+            Enter the alias of the tab who's properties should be displayed. If left blank, the first tab on the doc type will be used.            
         </p>
         <p>
-            <b>Name template:</b><br />
-            Enter an angular expression to evaluate against each item for its name.
+            <b>Name template:</b><br/>
+            Enter an angular expression to evaluate against each item for its name.            
         </p>
     </div>
 </div>

--- a/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.doctypepicker.html
+++ b/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.doctypepicker.html
@@ -1,6 +1,50 @@
-﻿<div id="{{model.alias}}" ng-controller="Our.Umbraco.NestedContent.Controllers.DocTypePickerController">
-    <select 
-        id="{{model.alias}}_select"
-        ng-options="dt.guid as dt.name for dt in model.docTypes | orderBy: 'name'"
-        ng-model="model.value" multiple=""></select>
+﻿<div id="{{model.alias}}" class="nested-content__doctypepicker" ng-controller="Our.Umbraco.NestedContent.Controllers.DocTypePickerController">
+    <div>
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>
+                        Document type
+                    </th>
+                    <th>
+                        Tab alias
+                    </th>
+                    <th>
+                        Name template
+                    </th>
+                    <th />
+                </tr>
+            </thead>
+            <tbody>
+                <tr ng-repeat="config in model.value">
+                    <td>
+                        <select id="{{model.alias}}_select"
+                                ng-options="dt.alias as dt.name for dt in model.docTypes | orderBy: 'name'"
+                                ng-model="config.alias"></select>
+                    </td>
+                    <td>
+                        <input type="text" ng-model="config.tabAlias" />
+                    </td>
+                    <td>
+                        <input type="text" ng-model="config.nameTemplate" />
+                    </td>
+                    <td>
+                        <a class="btn btn-danger" ng-click="remove($index)" ng-show="model.value.length > 1">Remove</a>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <a class="btn" ng-click="add()">Add</a>
+    </div>
+    <br />
+    <div class="nested-content__help-text ">
+        <p>
+            <b>Tab:</b><br />
+            Enter the alias of the tab who's properties should be displayed. If left blank, the first tab on the doc type will be used.
+        </p>
+        <p>
+            <b>Name template:</b><br />
+            Enter an angular expression to evaluate against each item for its name.
+        </p>
+    </div>
 </div>

--- a/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.doctypepicker.html
+++ b/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.doctypepicker.html
@@ -37,10 +37,13 @@
                 </tr>
             </tbody>
         </table>
-        <a class="btn" ng-click="add()">Add</a>
+        <div>
+            <a class="btn" ng-click="add()">Add</a>
+            <i class="icon icon-help-alt medium nested-content__help-icon" ng-click="showHelpText = !showHelpText"></i>
+        </div>
     </div>
     <br/>
-    <div class="nested-content__help-text ">
+    <div class="nested-content__help-text" ng-show="showHelpText">
         <p>
             <b>Tab:</b><br/>
             Enter the alias of the tab who's properties should be displayed. If left blank, the first tab on the doc type will be used.            

--- a/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.doctypepicker.html
+++ b/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.doctypepicker.html
@@ -1,6 +1,6 @@
 ﻿<div id="{{model.alias}}" ng-controller="Our.Umbraco.NestedContent.Controllers.DocTypePickerController">
     <select 
         id="{{model.alias}}_select"
-        ng-options="dt.guid as dt.name for dt in model.docTypes"
-        ng-model="model.value"></select>
+        ng-options="dt.guid as dt.name for dt in model.docTypes | orderBy: 'name'"
+        ng-model="model.value" multiple=""></select>
 </div>

--- a/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.html
+++ b/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.html
@@ -36,7 +36,7 @@
         </div>
 
         <div class="nested-content__footer-bar" ng-hide="nodes.length >= maxItems">
-            <a class="nested-content__icon" ng-click="openNodeTypePicker()" prevent-default>
+            <a class="nested-content__icon" ng-click="openNodeTypePicker($event)" prevent-default>
                 <i class=" icon icon-add"></i>
             </a>
         </div>

--- a/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.html
+++ b/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.html
@@ -36,9 +36,25 @@
         </div>
 
         <div class="nested-content__footer-bar" ng-hide="nodes.length >= maxItems">
-            <a class="nested-content__icon" ng-click="addNode()" prevent-default>
+            <a class="nested-content__icon" ng-click="openNodeTypePicker()" prevent-default>
                 <i class=" icon icon-add"></i>
             </a>
+        </div>
+
+        <div class="usky-grid" ng-if="overlayMenu.show">
+            <div class="cell-tools-menu" ng-style="overlayMenu.style" delayed-mouseleave="closeNodeTypePicker()">
+                <h5>
+                    <localize key="grid_insertControl" />
+                </h5>
+                <ul class="elements">
+                    <li ng-repeat="scaffold in overlayMenu.scaffolds | orderBy: 'name'">
+                        <a ng-click="addNode(scaffold.alias)" href>
+                            <i class="icon {{scaffold.icon}}"></i>
+                            {{scaffold.name}}
+                        </a>
+                    </li>
+                </ul>
+            </div>
         </div>
 
     </ng-form>

--- a/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.html
+++ b/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.html
@@ -24,7 +24,7 @@
                 </div> 
             
                 <div class="nested-content__content" ng-show="$parent.currentNode.id == node.id && !$parent.sorting">
-                    <nested-content-editor ng-model="node" tab-alias="tabAlias" />
+                    <nested-content-editor ng-model="node" tab-alias="ncTabAlias" />
                 </div>
         
             </div>
@@ -47,7 +47,7 @@
                     <localize key="grid_insertControl" />
                 </h5>
                 <ul class="elements">
-                    <li ng-repeat="scaffold in overlayMenu.scaffolds | orderBy: 'name'">
+                    <li ng-repeat="scaffold in overlayMenu.scaffolds">
                         <a ng-click="addNode(scaffold.alias)" href>
                             <i class="icon {{scaffold.icon}}"></i>
                             {{scaffold.name}}


### PR DESCRIPTION
Make it possible to add multiple different doctypes to the item list.

**Please note** that this PR changes the data format for both the prevalues and the content editor, and it is not backwards compatible.
