### PR TITLE
Proposed visual tweaks for list items

### DIFF
--- a/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Css/nestedcontent.css
+++ b/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Css/nestedcontent.css
@@ -50,6 +50,7 @@
 {
     float: left;
     line-height: 20px;
+    font-weight: bold;
 }
 
 .nested-content__icons 

--- a/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Css/nestedcontent.css
+++ b/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Css/nestedcontent.css
@@ -43,6 +43,7 @@
     padding: 15px 20px; 
     border-bottom: 1px dashed #e0e0e0;
     text-align: right;
+    cursor: pointer;
 }
 
 .nested-content__heading

--- a/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Css/nestedcontent.css
+++ b/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Css/nestedcontent.css
@@ -14,7 +14,7 @@
 .nested-content__item--active:not(.nested-content__item--single)
 {
     border-left: 4px solid #dd7f4e;
-	border-top: none;
+    border-top: none;
     margin-left: -4px;
     background: #f8f8f8;
 }

--- a/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Css/nestedcontent.css
+++ b/Src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Css/nestedcontent.css
@@ -11,6 +11,14 @@
     background: white;
 }
 
+.nested-content__item--active:not(.nested-content__item--single)
+{
+    border-left: 4px solid #dd7f4e;
+	border-top: none;
+    margin-left: -4px;
+    background: #f8f8f8;
+}
+
 .nested-content__item.ui-sortable-placeholder 
 {
     background: #f8f8f8;


### PR DESCRIPTION
These are a couple of visual changes we've made to the CSS file, to make editing **Nested Content** items in _list mode_ a little easier for our editors, by providing some more obvious visual cues.

Here's a picture of the changed look:

![nestedcontent_styled](https://cloud.githubusercontent.com/assets/5463/6906959/74a37b18-d732-11e4-99f6-2df07bd1e9b0.png)

The active item gets a background color and a coloured border on the left, so it's easy to see how much is included. Furthermore, the headers/labels are changed to bold, and they get a pointer cursor (i.e. the familiar hand) to show they're clickable at their full width.

The styles are not applied in the super secret "single" mode.

It's all totally open for discussion, of course :-)
