### PR TITLE
Implemented nestedContentSubmitWatcher directive to get around the pr…

### DIFF
--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
@@ -340,8 +340,8 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
 
         // submit watcher handling:  
         // because some property editors use the "formSubmitting" event to set/clean up their model.value,  
-        // we need to monitor the "formSubmitting" event from a custom property and broadcast our own event  
-        // to forcefully update the appropriate model.value's
+        // we need to monitor the "formSubmitting" event from a custom property so we can update our model
+        // after all the children are done updating theirs.
 
         // A directive is added right after each node is rendered, and hooks into these callback methods.
         // We have a counter so that the directive calling these methods can determine whether it's the one

--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
@@ -310,7 +310,7 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
             return node;
         }
 
-        $scope.$watch("nodes", function () {
+        var updateModel = function () {
             if (inited) {
                 var newValues = [];
                 for (var i = 0; i < $scope.nodes.length; i++) {
@@ -332,7 +332,28 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
                 }
                 $scope.model.value = newValues;
             }
+        }
+        
+        $scope.$watch("nodes", function () {
+            updateModel();
         }, true);
+
+        // submit watcher handling:  
+        // because some property editors use the "formSubmitting" event to set/clean up their model.value,  
+        // we need to monitor the "formSubmitting" event from a custom property and broadcast our own event  
+        // to forcefully update the appropriate model.value's
+
+        // A directive is added right after each node is rendered, and hooks into these callback methods.
+        // We have a counter so that the directive calling these methods can determine whether it's the one
+        // to trigger the onSubmit callback method or not, thereby making sure only the latest one triggers 
+        // the update as all previous ones are going to be invalid.
+        $scope.activeSubmitWatcher = 0;  
+        $scope.submitWatcherOnLoad = function () {
+            return ++$scope.activeSubmitWatcher; 
+        }  
+        $scope.submitWatcherOnSubmit = function () {  
+            updateModel();
+        }
 
         var guid = function () {
             function _p8(s) {

--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.directives.js
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.directives.js
@@ -32,3 +32,29 @@
 
     }
 ]);
+
+angular.module("umbraco.directives").directive('nestedContentSubmitWatcher', function ($rootScope) {
+    var link = function (scope, element, attrs, ngModelCtrl) {
+        // call the load callback on scope to obtain the ID of this submit watcher
+        var id = scope.loadCallback();
+        var unSubscribe = scope.$on("formSubmitting", function (ev, args) {
+            // on the "formSubmitting" event, call the submit callback on scope to notify the nestedContent controller to do it's magic
+            if (id == scope.activeSubmitWatcher) {
+                scope.submitCallback();
+            }
+        });
+    }
+
+    return {
+        restrict: "E",
+        replace: true,
+        template: "",
+        scope: {
+            loadCallback: '=',
+            submitCallback: '=',
+            activeSubmitWatcher: '='
+        },
+        link: link
+    }
+});
+

--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.html
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.html
@@ -27,6 +27,7 @@
                     <nested-content-editor ng-model="node" tab-alias="ncTabAlias" />
                 </div>
         
+                <nested-content-submit-watcher active-submit-watcher="$parent.activeSubmitWatcher" load-callback="$parent.submitWatcherOnLoad" submit-callback="$parent.submitWatcherOnSubmit"></nested-content-submit-watcher>
             </div>
         
         </div>


### PR DESCRIPTION
…oblem of child controls that use the formSubmitted event to save their values back to the scope.

This relates to issue #20 - Saving Macro Container properties to Nested Content doesn't always work and is based on work in Archetype by @kjac.

This implementation is simplified and doesn't require creating another broadcast event as the directive binds to the callbacks on the $parent instead of the scoped node.  As such it may be a little more optimised in terms of performance as we're only relying on the formSubmitted event and not broadcasting another one.
