### PR TITLE
Adds localized titles to anchors surrounding icons.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ src/packages/*/**
 build/App_plugins/
 build/bin/
 assets/
+src/Our.Umbraco.NestedContent/Settings.StyleCop

--- a/src/Our.Umbraco.NestedContent/Properties/VersionInfo.cs
+++ b/src/Our.Umbraco.NestedContent/Properties/VersionInfo.cs
@@ -14,6 +14,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("1.0.0-local-000100")]
+[assembly: AssemblyInformationalVersion("1.0.6-beta")]
 
 

--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
@@ -55,13 +55,33 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
     "$filter",
     "contentResource",
     "Our.Umbraco.NestedContent.Resources.NestedContentResources",
+    "localizationService",
 
-    function ($scope, $interpolate, $filter, contentResource, ncResources) {
+    function ($scope, $interpolate, $filter, contentResource, ncResources, localizationService) {
 
         //$scope.model.config.contentTypes;
         //$scope.model.config.minItems;
         //$scope.model.config.maxItems;
         //console.log($scope);
+
+        $scope.editIconTitle = '';
+        $scope.moveIconTitle = '';
+        $scope.deleteIconTitle = '';
+
+        // localize the edit icon title
+        localizationService.localize('general_edit').then(function (value) {
+            $scope.editIconTitle = value;
+        });
+
+        // localize the delete icon title
+        localizationService.localize('general_delete').then(function (value) {
+            $scope.deleteIconTitle = value;
+        });
+
+        // localize the move icon title
+        localizationService.localize('actions_move').then(function (value) {
+            $scope.moveIconTitle = value;
+        });
 
         var inited = false;
 

--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.html
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.html
@@ -12,13 +12,13 @@
                     <div class="nested-content__heading"><i ng-if="showIcons" class="icon" ng-class="$parent.getIcon($index)"></i><span ng-bind="$parent.getName($index)"></span></div>
 
                     <div class="nested-content__icons">
-                        <a class="nested-content__icon nested-content__icon--edit" ng-class="{ 'nested-content__icon--active' : $parent.currentNode.id == node.id }" ng-click="$parent.editNode($index); $event.stopPropagation();" prevent-default>
+                        <a class="nested-content__icon nested-content__icon--edit" title="{{editIconTitle}}" ng-class="{ 'nested-content__icon--active' : $parent.currentNode.id == node.id }" ng-click="$parent.editNode($index); $event.stopPropagation();" prevent-default>
                             <i class="icon icon-edit"></i>
                         </a>
-                        <a class="nested-content__icon nested-content__icon--move" ng-click="$event.stopPropagation();" prevent-default>
+                        <a class="nested-content__icon nested-content__icon--move" title="{{moveIconTitle}}" ng-click="$event.stopPropagation();" prevent-default>
                             <i class="icon icon-navigation"></i>
                         </a>
-                        <a class="nested-content__icon nested-content__icon--delete" ng-class="{ 'nested-content__icon--disabled': $parent.nodes.length <= $parent.minItems }" ng-click="$parent.deleteNode($index); $event.stopPropagation();" prevent-default>
+                        <a class="nested-content__icon nested-content__icon--delete" title="{{deleteIconTitle}}" ng-class="{ 'nested-content__icon--disabled': $parent.nodes.length <= $parent.minItems }" ng-click="$parent.deleteNode($index); $event.stopPropagation();" prevent-default>
                             <i class="icon icon-trash"></i>
                         </a>
                     </div>


### PR DESCRIPTION
Hey guys, Not sure if you want this, but in Merchello I've now "borrowed" your icon styles in an attempts to keep unified with the back office and with some of the great property editors (like NC) out there.

In Merchello, I needed to add a few more that were not as obvious as edit, move and delete so I added localized titles to the anchor surrounding the icon (i). I've updated my fork of Nested Content to include these for you to evaluate and decide whether or not you think it's a good idea.
