### PR TITLE
Added support for doctype composition

### DIFF
--- a/src/Our.Umbraco.NestedContent/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Our.Umbraco.NestedContent/PropertyEditors/NestedContentPropertyEditor.cs
@@ -151,7 +151,7 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
 
                     foreach (var propKey in propValueKeys)
                     {
-                        var propType = contentType.PropertyTypes.FirstOrDefault(x => x.Alias == propKey);
+                        var propType = contentType.CompositionPropertyTypes.FirstOrDefault(x => x.Alias == propKey);
                         if (propType == null)
                         {
                             if (IsSystemPropertyKey(propKey) == false)
@@ -216,7 +216,7 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
 
                     foreach (var propKey in propValueKeys)
                     {
-                        var propType = contentType.PropertyTypes.FirstOrDefault(x => x.Alias == propKey);
+                        var propType = contentType.CompositionPropertyTypes.FirstOrDefault(x => x.Alias == propKey);
                         if (propType == null)
                         {
                             if (IsSystemPropertyKey(propKey) == false)
@@ -280,7 +280,7 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
 
                     foreach (var propKey in propValueKeys)
                     {
-                        var propType = contentType.PropertyTypes.FirstOrDefault(x => x.Alias == propKey);
+                        var propType = contentType.CompositionPropertyTypes.FirstOrDefault(x => x.Alias == propKey);
                         if (propType == null)
                         {
                             if (IsSystemPropertyKey(propKey) == false)
@@ -342,7 +342,7 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
 
                     foreach (var propKey in propValueKeys)
                     {
-                        var propType = contentType.PropertyTypes.FirstOrDefault(x => x.Alias == propKey);
+                        var propType = contentType.CompositionPropertyTypes.FirstOrDefault(x => x.Alias == propKey);
                         if (propType != null)
                         {
                             // It would be better to pass this off to the individual property editors


### PR DESCRIPTION
Hey, I was trying to use a document type which uses composition and the values weren't being saved, I've found out that PropertyTypes only contains properties which are added to the document type directly so we need to check CompositionPropertyTypes for the property also.
