### PR TITLE
Added nested property editor validation support

### DIFF
--- a/src/Our.Umbraco.NestedContent/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Our.Umbraco.NestedContent/PropertyEditors/NestedContentPropertyEditor.cs
@@ -353,6 +353,7 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
                             {
                                 foreach (ValidationResult result in validator.Validate(propValues[propKey], propPrevalues, propertyEditor))
                                 {
+                                    result.ErrorMessage = "Item " + (i + 1) + " '" + propType.Name + "' " + result.ErrorMessage;
                                     yield return result;
                                 }
                             }


### PR DESCRIPTION
Hey, I've looked at the validation and I've found a way to call the validators for each property.
Mandatory and regex validation is still needed tho.

I've only tested this on a small subset of property editors but it seems to do the validation correct.
