### PR TITLE
Fixes Issue #38 Returns null if there are no objects in the collection

### DIFF
--- a/src/Our.Umbraco.NestedContent/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Our.Umbraco.NestedContent/PropertyEditors/NestedContentPropertyEditor.cs
@@ -262,7 +262,11 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
 
                 var value = JsonConvert.DeserializeObject<List<object>>(editorValue.Value.ToString());
                 if (value == null)
-                    return string.Empty;
+                    return null;
+
+                // Issue #38 - Keep recursive property lookups working
+                if (!value.Any()) 
+                    return null;
 
                 // Process value
                 for (var i = 0; i < value.Count; i++)


### PR DESCRIPTION
This fixes Issue #38 whereby recursive property lookups were not working as expected when a property with a previous nested content property editor previously had a value which was later removed. [See the forum post](https://our.umbraco.org/projects/backoffice-extensions/nested-content/nested-content-feedback/72767-problems-calling-getpropertyvalue-recursively-on-an-empty-property-which-previously-had-a-value).
