### PR TITLE
Performance boost

### DIFF
--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.html
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.html
@@ -25,7 +25,7 @@
 
                 </div>
 
-                <div class="nested-content__content" ng-show="$parent.currentNode.id == node.id && !$parent.sorting">
+                <div class="nested-content__content" ng-show="$parent.currentNode.id == node.id && !$parent.sorting" ng-if="$parent.currentNode.id == node.id && !$parent.sorting">
                     <nested-content-editor ng-model="node" tab-alias="ncTabAlias" />
                 </div>
 


### PR DESCRIPTION
I added ng-if so the nested content editor doesn't get loaded until it's shown. With ng-show all nested content editors will have their databound, causing a long loading time and even javascript warnings for long running scripts if you are editing a very long list. 

With ng-if added data only get's bound when the editor is actually shown.
