### PR TITLE
Add support for disabling nested content items

### DIFF
--- a/src/Our.Umbraco.NestedContent/Extensions/PublishedPropertyTypeExtensions.cs
+++ b/src/Our.Umbraco.NestedContent/Extensions/PublishedPropertyTypeExtensions.cs
@@ -64,6 +64,12 @@ namespace Our.Umbraco.NestedContent.Extensions
                             continue;
                         }
 
+                        JToken disabled;
+                        if (item.TryGetValue("ncDisabled", out disabled) && disabled.Value<bool>())
+                        {
+                            continue;
+                        }
+
                         var publishedContentType = PublishedContentType.Get(PublishedItemType.Content, contentTypeAlias);
                         if (publishedContentType == null)
                         {

--- a/src/Our.Umbraco.NestedContent/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Our.Umbraco.NestedContent/PropertyEditors/NestedContentPropertyEditor.cs
@@ -37,6 +37,7 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
                 {NestedContentPreValueEditor.ContentTypesPreValueKey, ""},
                 {"minItems", 0},
                 {"maxItems", 0},
+                {"allowDisabling", "0"},
                 {"confirmDeletes", "1"},
                 {"showIcons", "1"}
             };
@@ -67,6 +68,9 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
 
             [PreValueField("showIcons", "Show Icons", "boolean", Description = "Set whether to show the items doc type icon in the list.")]
             public string ShowIcons { get; set; }
+
+            [PreValueField("allowDisabling", "Allow Disabling", "boolean", Description = "Set whether to allow disabling items.")]
+            public string AllowDisabling { get; set; }
 
             [PreValueField("hideLabel", "Hide Label", "boolean", Description = "Set whether to hide the editor label and have the list take up the full width of the editor window.")]
             public string HideLabel { get; set; }
@@ -389,7 +393,7 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
 
         private static bool IsSystemPropertyKey(string propKey)
         {
-            return propKey == "name" || propKey == ContentTypeAliasPropertyKey;
+            return propKey == "name" || propKey == ContentTypeAliasPropertyKey || propKey == "ncDisabled";
         }
     }
 }

--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Css/nestedcontent.css
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Css/nestedcontent.css
@@ -18,6 +18,12 @@
     background: #f8f8f8;
 }
 
+.nested-content__item--disabled .nested-content__heading,
+.nested-content__item--disabled .nested-content__icon--disable
+{
+    opacity: 0.3;
+}
+
 .nested-content__item.ui-sortable-placeholder 
 {
     background: #f8f8f8;
@@ -75,6 +81,7 @@
 }
 
 .nested-content__header-bar:hover .nested-content__icons,
+.nested-content__item--disabled .nested-content__icon--disable:hover,
 .nested-content__item--active > .nested-content__header-bar .nested-content__icons
 {
     opacity: 1;

--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
@@ -8,7 +8,7 @@
         $scope.add = function() {
             $scope.model.value.push({
                     // As per PR #4, all stored content type aliases must be prefixed "nc" for easier recognition.
-                    // For good measure we'll also prefix the tab alias "nc" 
+                    // For good measure we'll also prefix the tab alias "nc"
                     ncAlias: "",
                     ncTabAlias: "",
                     nameTemplate: ""
@@ -106,6 +106,7 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
         $scope.singleMode = $scope.minItems == 1 && $scope.maxItems == 1;
         $scope.showIcons = $scope.model.config.showIcons || true;
         $scope.wideMode = $scope.model.config.hideLabel == "1";
+        $scope.allowDisabling = $scope.model.config.allowDisabling === "1";
 
         $scope.overlayMenu = {
             show: false,
@@ -189,6 +190,11 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
                     updateModel();
                 }
             }
+        };
+
+        $scope.toggleDisabled = function (idx) {
+            $scope.nodes[idx].ncDisabled = !$scope.nodes[idx].ncDisabled;
+            updateModel();
         };
 
         $scope.getName = function (idx) {
@@ -288,7 +294,7 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
         var initIfAllScaffoldsHaveLoaded = function() {
             // Initialize when all scaffolds have loaded
             if ($scope.model.config.contentTypes.length == scaffoldsLoaded) {
-                // Because we're loading the scaffolds async one at a time, we need to 
+                // Because we're loading the scaffolds async one at a time, we need to
                 // sort them explicitly according to the sort order defined by the data type.
                 var contentTypeAliases = [];
                 _.each($scope.model.config.contentTypes, function(contentType) {
@@ -332,6 +338,10 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
 
             node.id = guid();
             node.ncContentTypeAlias = scaffold.contentTypeAlias;
+            node.ncDisabled = false;
+            if(item) {
+              node.ncDisabled = item.ncDisabled;
+            }
 
             for (var t = 0; t < node.tabs.length; t++) {
                 var tab = node.tabs[t];
@@ -339,7 +349,7 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
                     var prop = tab.properties[p];
                     prop.propertyAlias = prop.alias;
                     prop.alias = $scope.model.alias + "___" + prop.alias;
-                    // Force validation to occur server side as this is the 
+                    // Force validation to occur server side as this is the
                     // only way we can have consistancy between mandatory and
                     // regex validation messages. Not ideal, but it works.
                     prop.validation = {
@@ -369,7 +379,8 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
                     var node = $scope.nodes[i];
                     var newValue = {
                         name: node.name,
-                        ncContentTypeAlias: node.ncContentTypeAlias
+                        ncContentTypeAlias: node.ncContentTypeAlias,
+                        ncDisabled: node.ncDisabled
                     };
                     for (var t = 0; t < node.tabs.length; t++) {
                         var tab = node.tabs[t];

--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.html
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.html
@@ -5,7 +5,7 @@
 
         <div class="nested-content__items" ng-hide="nodes.length == 0" ui-sortable="sortableOptions" ng-model="nodes">
 
-            <div class="nested-content__item" ng-repeat="node in nodes" ng-class="{ 'nested-content__item--active' : $parent.realCurrentNode.id == node.id, 'nested-content__item--single' : $parent.singleMode }">
+            <div class="nested-content__item" ng-repeat="node in nodes" ng-class="{ 'nested-content__item--active' : $parent.realCurrentNode.id == node.id, 'nested-content__item--single' : $parent.singleMode, 'nested-content__item--disabled': node.ncDisabled }">
 
                 <div class="nested-content__header-bar" ng-click="$parent.editNode($index)" ng-hide="$parent.singleMode">
 
@@ -14,6 +14,9 @@
                     <div class="nested-content__icons">
                         <a class="nested-content__icon nested-content__icon--edit" title="{{editIconTitle}}" ng-class="{ 'nested-content__icon--active' : $parent.realCurrentNode.id == node.id }" ng-click="$parent.editNode($index); $event.stopPropagation();" prevent-default>
                             <i class="icon icon-edit"></i>
+                        </a>
+                        <a class="nested-content__icon nested-content__icon--disable" title="{{disableIconTitle}}" ng-click="$parent.toggleDisabled($index); $event.stopPropagation();" ng-if="$parent.allowDisabling" prevent-default>
+                            <i class="icon icon-power"></i>
                         </a>
                         <a class="nested-content__icon nested-content__icon--move" title="{{moveIconTitle}}" ng-click="$event.stopPropagation();" prevent-default>
                             <i class="icon icon-navigation"></i>


### PR DESCRIPTION
This adds support for disabling nested content items.
Disabled items won't be returned by the value converter, so no extra implementation code is needed.

It can be configured on the datatype whether to allow disabling of items.

![disable-items](https://cloud.githubusercontent.com/assets/379886/15548049/e0454372-22a6-11e6-910d-d5ab1a41ce04.png)
