### PR TITLE
Fixed icons border when using in LeBlender

### DIFF
--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Css/nestedcontent.css
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Css/nestedcontent.css
@@ -185,3 +185,12 @@
 .form-horizontal .nested-content--narrow .controls-row .umb-dropdown {
     width: 99%;
 }
+
+#blender-grid-editor-parameter .nested-content__icon {
+    padding: 4px 4px;
+}
+
+    #blender-grid-editor-parameter .nested-content__icon i {
+        margin-left: 2px;
+        margin-right: 2px;
+    }


### PR DESCRIPTION
Hi @leekelleher and @mattbrailsford :-)

I made a small change to the stylesheet, in NC, because i'm using it with the plugin LeBlender, and the icons border where a little too wide.

Before:
![before](https://cloud.githubusercontent.com/assets/9005889/16913846/0e76634a-4cee-11e6-8aff-2b723f74b286.PNG)

After:
![after](https://cloud.githubusercontent.com/assets/9005889/16913847/0e8c3260-4cee-11e6-95b9-202f1e7c1935.PNG)

As i see its a combine of some style LeBlender has and NC has but with the following style i added it should look normal, both when used without LeBlender and with it, because it looks after the "blender-grid-editor-parameter" id :-)
