### PR TITLE
Add feature to use {{index}} in a name template

### DIFF
--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
@@ -200,7 +200,15 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
                 var contentType = $scope.getContentTypeConfig($scope.model.value[idx].ncContentTypeAlias);
 
                 if (contentType != null && contentType.nameExp) {
-                    var newName = contentType.nameExp($scope.model.value[idx]); // Run it against the stored dictionary value, NOT the node object
+                    var item = $scope.model.value[idx]; // Run it against the stored dictionary value, NOT the node object
+
+                    if (contentType.nameTemplate.indexOf("{{index}}") !== -1) {
+                        var cloneItem = JSON.parse(JSON.stringify(item));
+                        cloneItem.index = (idx + 1); // inject the index position to the object
+                        item = cloneItem;
+                    }
+
+                    var newName = contentType.nameExp(item);
                     if (newName && (newName = $.trim(newName))) {
                         name = newName;
                     }

--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.doctypepicker.html
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.doctypepicker.html
@@ -52,7 +52,7 @@
         </p>
         <p>
             <b>Name template:</b><br/>
-            Enter an angular expression to evaluate against each item for its name.            
+            Enter an angular expression to evaluate against each item for its name. Use <code ng-non-bindable>{{index}}</code> to display the item index  
         </p>
     </div>
 </div>


### PR DESCRIPTION
Added the ability to display the index position in a name template

e.g "Column {{index}}" resulting in "Column 1, Column 2 etc"
