### PR TITLE
Adds Group to the PropertyEditor attribute

### DIFF
--- a/src/Our.Umbraco.NestedContent/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Our.Umbraco.NestedContent/PropertyEditors/NestedContentPropertyEditor.cs
@@ -15,7 +15,7 @@ using Umbraco.Web.PropertyEditors;
 
 namespace Our.Umbraco.NestedContent.PropertyEditors
 {
-    [PropertyEditor(NestedContentPropertyEditor.PropertyEditorAlias, "Nested Content", "~/App_Plugins/NestedContent/Views/nestedcontent.html", ValueType = "JSON")]
+    [PropertyEditor(NestedContentPropertyEditor.PropertyEditorAlias, "Nested Content", "~/App_Plugins/NestedContent/Views/nestedcontent.html", ValueType = "JSON", Group = "Nested Content")]
     public class NestedContentPropertyEditor : PropertyEditor
     {
         internal const string ContentTypeAliasPropertyKey = "ncContentTypeAlias";


### PR DESCRIPTION
Add a group to the property editor attribute. This tidies the select editor dialog by grouping all nested content editors together
