### PR TITLE
Reintroduces ~ for making it work in subfolders (issue #77)

### DIFF
--- a/src/Our.Umbraco.NestedContent/PropertyEditors/NestedContentPropertyEditor.cs
+++ b/src/Our.Umbraco.NestedContent/PropertyEditors/NestedContentPropertyEditor.cs
@@ -15,7 +15,7 @@ using Umbraco.Web.PropertyEditors;
 
 namespace Our.Umbraco.NestedContent.PropertyEditors
 {
-    [PropertyEditor(NestedContentPropertyEditor.PropertyEditorAlias, "Nested Content", "/App_Plugins/NestedContent/Views/nestedcontent.html", ValueType = "JSON")]
+    [PropertyEditor(NestedContentPropertyEditor.PropertyEditorAlias, "Nested Content", "~/App_Plugins/NestedContent/Views/nestedcontent.html", ValueType = "JSON")]
     public class NestedContentPropertyEditor : PropertyEditor
     {
         internal const string ContentTypeAliasPropertyKey = "ncContentTypeAlias";
@@ -53,7 +53,7 @@ namespace Our.Umbraco.NestedContent.PropertyEditors
         {
             internal const string ContentTypesPreValueKey = "contentTypes";
 
-            [PreValueField(ContentTypesPreValueKey, "Doc Types", "/App_Plugins/NestedContent/Views/nestedcontent.doctypepicker.html", Description = "Select the doc types to use as the data blueprint.")]
+            [PreValueField(ContentTypesPreValueKey, "Doc Types", "~/App_Plugins/NestedContent/Views/nestedcontent.doctypepicker.html", Description = "Select the doc types to use as the data blueprint.")]
             public string[] ContentTypes { get; set; }
 
             [PreValueField("minItems", "Min Items", "number", Description = "Set the minimum number of items allowed.")]


### PR DESCRIPTION
The original problem was caused by a bug in umbraco 7.2 which was later resolved in 7.3
I've see the same change (adding ~/) has been to vorto so I guess it's safe to say we can apply same fix to nested-contents as well