### PR TITLE
Set $dirty property on form

### DIFF
--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
@@ -113,12 +113,20 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
             style: {}
         };
 
+        // helper to force the current form into the dirty state
+        $scope.setDirty = function () {
+            if ($scope.propertyForm) {
+                $scope.propertyForm.$setDirty();
+            }
+        };
+
         $scope.addNode = function (alias) {
             var scaffold = $scope.getScaffold(alias);
 
             var newNode = initNode(scaffold, null);
 
             $scope.currentNode = newNode;
+            $scope.setDirty();
 
             $scope.closeNodeTypePicker();
         };
@@ -190,10 +198,12 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
                 if ($scope.model.config.confirmDeletes && $scope.model.config.confirmDeletes == 1) {
                     if (confirm("Are you sure you want to delete this item?")) {
                         $scope.nodes.splice(idx, 1);
+                        $scope.setDirty();
                         updateModel();
                     }
                 } else {
                     $scope.nodes.splice(idx, 1);
+                    $scope.setDirty();
                     updateModel();
                 }
             }
@@ -252,6 +262,9 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
                 $scope.$apply(function () {
                     $scope.sorting = true;
                 });
+            },
+            update: function (ev, ui) {
+                $scope.setDirty();
             },
             stop: function (ev, ui) {
                 $("#nested-content--" + $scope.model.id + " .umb-rte textarea").each(function () {

--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
@@ -56,9 +56,10 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
     "$timeout",
     "contentResource",
     "localizationService",
+    "iconHelper",
     "Our.Umbraco.NestedContent.Resources.NestedContentResources",
 
-    function ($scope, $interpolate, $filter, $timeout, contentResource, localizationService, ncResources) {
+    function ($scope, $interpolate, $filter, $timeout, contentResource, localizationService, iconHelper, ncResources) {
 
         //$scope.model.config.contentTypes;
         //$scope.model.config.minItems;
@@ -139,15 +140,10 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
             // this could be used for future limiting on node types
             $scope.overlayMenu.scaffolds = [];
             _.each($scope.scaffolds, function (scaffold) {
-                var icon = scaffold.icon;
-                // workaround for when no icon is chosen for a doctype
-                if (icon == ".sprTreeFolder") {
-                    icon = "icon-folder";
-                }
                 $scope.overlayMenu.scaffolds.push({
                     alias: scaffold.contentTypeAlias,
                     name: scaffold.contentTypeName,
-                    icon: icon
+                    icon: iconHelper.convertFromLegacyIcon(scaffold.icon)
                 });
             });
 
@@ -246,7 +242,7 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
 
         $scope.getIcon = function (idx) {
             var scaffold = $scope.getScaffold($scope.model.value[idx].ncContentTypeAlias);
-            return scaffold && scaffold.icon && scaffold.icon !== ".sprTreeFolder" ? scaffold.icon : "icon-folder";
+            return scaffold && scaffold.icon ? iconHelper.convertFromLegacyIcon(scaffold.icon) : "icon-folder";
         }
 
         $scope.sortableOptions = {


### PR DESCRIPTION
Issue: https://github.com/umco/umbraco-nested-content/issues/113

This set $dirty property on form, when adding a new item, removing an item or changing order.
I have also changed the scaffold.icon to use `iconHelper` since the legacy icons could be others than `.sprTreeFolder`.
https://github.com/umbraco/Umbraco-CMS/blob/5397f2c53acbdeb0805e1fe39fda938f571d295a/src/Umbraco.Web.UI.Client/src/common/services/iconhelper.service.js