### PR TITLE
Fix grid editors in nested content

### DIFF
--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
@@ -378,7 +378,10 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
 
         var updateModel = function () {
             if ($scope.realCurrentNode) {
+                var currentTabIndex = $scope.nodes.findIndex(getCurrentNodeIndex);
+                var gridProps = $scope.realCurrentNode.tabs[0].properties.map(backupGridConfig);
                 $scope.$broadcast("ncSyncVal", { id: $scope.realCurrentNode.id });
+                $scope.nodes[currentTabIndex].tabs[0].properties = $scope.nodes[currentTabIndex].tabs[0].properties.map(restoreGridConfig.bind(null, gridProps));
             }
             if (inited) {
                 var newValues = [];
@@ -423,6 +426,18 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
             }
             return _p8() + _p8(true) + _p8(true) + _p8();
         };
+
+        var getCurrentNodeIndex = function (node) {
+            return node.id === $scope.realCurrentNode.id;
+        }
+
+        var backupGridConfig = function (prop) {
+            return prop.editor == "Umbraco.Grid" ? prop : false;
+        }
+
+        var restoreGridConfig = function (gridProps, prop, i) {
+            return gridProps[i] || prop;
+        }
     }
 
 ]);

--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
@@ -1,4 +1,4 @@
-﻿angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.DocTypePickerController", [
+angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.DocTypePickerController", [
 
     "$scope",
     "Our.Umbraco.NestedContent.Resources.NestedContentResources",
@@ -8,7 +8,7 @@
         $scope.add = function () {
             $scope.model.value.push({
                 // As per PR #4, all stored content type aliases must be prefixed "nc" for easier recognition.
-                // For good measure we'll also prefix the tab alias "nc" 
+                // For good measure we'll also prefix the tab alias "nc"
                 ncAlias: "",
                 ncTabAlias: "",
                 nameTemplate: ""
@@ -305,7 +305,7 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
         var initIfAllScaffoldsHaveLoaded = function () {
             // Initialize when all scaffolds have loaded
             if ($scope.model.config.contentTypes.length == scaffoldsLoaded) {
-                // Because we're loading the scaffolds async one at a time, we need to 
+                // Because we're loading the scaffolds async one at a time, we need to
                 // sort them explicitly according to the sort order defined by the data type.
                 var contentTypeAliases = [];
                 _.each($scope.model.config.contentTypes, function (contentType) {
@@ -356,7 +356,7 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
                     var prop = tab.properties[p];
                     prop.propertyAlias = prop.alias;
                     prop.alias = $scope.model.alias + "___" + prop.alias;
-                    // Force validation to occur server side as this is the 
+                    // Force validation to occur server side as this is the
                     // only way we can have consistancy between mandatory and
                     // regex validation messages. Not ideal, but it works.
                     prop.validation = {
@@ -378,10 +378,7 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
 
         var updateModel = function () {
             if ($scope.realCurrentNode) {
-                var currentTabIndex = $scope.nodes.findIndex(getCurrentNodeIndex);
-                var gridProps = $scope.realCurrentNode.tabs[0].properties.map(backupGridConfig);
                 $scope.$broadcast("ncSyncVal", { id: $scope.realCurrentNode.id });
-                $scope.nodes[currentTabIndex].tabs[0].properties = $scope.nodes[currentTabIndex].tabs[0].properties.map(restoreGridConfig.bind(null, gridProps));
             }
             if (inited) {
                 var newValues = [];
@@ -426,18 +423,6 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
             }
             return _p8() + _p8(true) + _p8(true) + _p8();
         };
-
-        var getCurrentNodeIndex = function (node) {
-            return node.id === $scope.realCurrentNode.id;
-        }
-
-        var backupGridConfig = function (prop) {
-            return prop.editor == "Umbraco.Grid" ? prop : false;
-        }
-
-        var restoreGridConfig = function (gridProps, prop, i) {
-            return gridProps[i] || prop;
-        }
     }
 
 ]);

--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.directives.js
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.directives.js
@@ -1,6 +1,8 @@
 ﻿angular.module("umbraco.directives").directive('nestedContentEditor', [
 
-    function () {
+    "Our.Umbraco.NestedContent.Services.NestedContentCallbacks",
+
+    function (NestedContentCallbacks) {
 
         var link = function ($scope) {
 
@@ -28,6 +30,9 @@
             // Listen for sync request
             var unsubscribe = $scope.$on("ncSyncVal", function (ev, args) {
                 if (args.id === $scope.model.id) {
+
+                    // Run callback
+                    NestedContentCallbacks.call("ncBeforeFormSubmitting", { scope: $scope });
 
                     // Tell inner controls we are submitting
                     $scope.$broadcast("formSubmitting", { scope: $scope });

--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.services.js
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.services.js
@@ -1,0 +1,25 @@
+angular.module('umbraco.services').factory('Our.Umbraco.NestedContent.Services.NestedContentCallbacks',
+
+  function() {
+    // Define available callbacks
+    var callbacks = {
+      'ncBeforeFormSubmitting': []
+    };
+
+    return {
+
+      callbacks: callbacks,
+
+      call: function(cb, args) {
+        cb = this.callbacks[cb];
+        if ( cb && Array.isArray(cb) && cb.length ) {
+          cb.forEach(function(func) {
+            typeof func != "function" || func(args);
+          });
+        }
+      }
+
+    };
+  }
+
+);

--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.html
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.html
@@ -25,7 +25,7 @@
 
                 </div>
 
-                <div class="nested-content__content" ng-show="$parent.realCurrentNode.id == node.id && !$parent.sorting">
+                <div class="nested-content__content" ng-if="$parent.realCurrentNode.id == node.id && !$parent.sorting">
                     <nested-content-editor ng-model="node" tab-alias="ncTabAlias" />
                 </div>
             </div>

--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.html
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Views/nestedcontent.html
@@ -25,7 +25,7 @@
 
                 </div>
 
-                <div class="nested-content__content" ng-if="$parent.realCurrentNode.id == node.id && !$parent.sorting">
+                <div class="nested-content__content" ng-show="$parent.realCurrentNode.id == node.id && !$parent.sorting">
                     <nested-content-editor ng-model="node" tab-alias="ncTabAlias" />
                 </div>
             </div>

--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/package.manifest
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/package.manifest
@@ -3,7 +3,8 @@
         '~/App_Plugins/NestedContent/Js/nestedcontent.filters.js',
         '~/App_Plugins/NestedContent/Js/nestedcontent.resources.js',
         '~/App_Plugins/NestedContent/Js/nestedcontent.directives.js',
-        '~/App_Plugins/NestedContent/Js/nestedcontent.controllers.js'
+        '~/App_Plugins/NestedContent/Js/nestedcontent.controllers.js',
+        '~/App_Plugins/NestedContent/Js/nestedcontent.services.js'
     ],
     "css" : [
         "~/App_Plugins/NestedContent/Css/nestedcontent.css"


### PR DESCRIPTION
This would resolve #109. I can't say it's the most eloquent solution, but it does allow you to have grid editors inside of nested content, which allows for incredibly powerful layouts.

Without this fix, the grid config is lost on close due to sending the formSubmitted signal to the grid.

- Backup and restore grid config when closing editor containing grids.
- Swap ng-if for ng-show to avoid re-initing the RTE. Not ideal, but does work.

Ideally, this should use ng-if and reinitialise any rich fields on show. It would also be preferable to reacquire the grid config on open, rather than simply storing it; However, I'm just stoked to get it working!