### PR TITLE
Helper methods for renaming aliases

### DIFF
--- a/src/Our.Umbraco.NestedContent/Extensions/JsonExtensions.cs
+++ b/src/Our.Umbraco.NestedContent/Extensions/JsonExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Newtonsoft.Json.Linq;
+
+namespace Our.Umbraco.NestedContent.Extensions
+{
+    internal static class JsonExtensions
+    {
+        public static void Rename(this JToken token, string newName)
+        {
+            var parent = token.Parent;
+
+            if (parent == null)
+                throw new InvalidOperationException("The parent is missing.");
+
+            var newToken = new JProperty(newName, token);
+            parent.Replace(newToken);
+        }
+    }
+}

--- a/src/Our.Umbraco.NestedContent/Models/JsonDbRow.cs
+++ b/src/Our.Umbraco.NestedContent/Models/JsonDbRow.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Our.Umbraco.NestedContent.Models
+{
+    /// <summary>
+    /// A utility class used to help modify JSON data from the Umbraco property data table
+    /// </summary>
+    internal class JsonDbRow
+    {
+        public int Id { get; set; }
+
+        public string RawData { get; set; }
+
+        public JToken Data
+        {
+            get
+            {
+                return (JToken)JsonConvert.DeserializeObject(RawData);
+            }
+            set
+            {
+                RawData = JsonConvert.SerializeObject(value);
+            }
+        }
+    }
+}

--- a/src/Our.Umbraco.NestedContent/Our.Umbraco.NestedContent.csproj
+++ b/src/Our.Umbraco.NestedContent/Our.Umbraco.NestedContent.csproj
@@ -228,6 +228,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Bootstrap.cs" />
+    <Compile Include="Extensions\JsonExtensions.cs" />
     <Compile Include="Extensions\PublishedPropertyTypeExtensions.cs" />
     <Compile Include="Converters\SingleNestedContentValueConverter.cs" />
     <Compile Include="Converters\NestedContentValueConverter.cs" />
@@ -236,6 +237,7 @@
     <Compile Include="Helpers\NestedContentHelper.cs" />
     <Compile Include="Models\DetachedPublishedContent.cs" />
     <Compile Include="Models\DetachedPublishedProperty.cs" />
+    <Compile Include="Models\JsonDbRow.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\VersionInfo.cs" />
     <Compile Include="PropertyEditors\NestedContentPropertyEditor.cs" />


### PR DESCRIPTION
Adds helper methods to programmatically aid with renaming a doctype/property alias or tab name.

@mattbrailsford These are a few methods that I found in Pegasus code. Thought they'd be more useful in NC itself. Sound ok?