### PR TITLE
Positions "Content Type selection" modal by CSS, not JS (fixes issue 120)

### DIFF
--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Css/nestedcontent.css
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Css/nestedcontent.css
@@ -185,3 +185,10 @@
 .form-horizontal .nested-content--narrow .controls-row .umb-dropdown {
     width: 99%;
 }
+
+.nested-content__node-type-picker .cell-tools-menu {
+    position: fixed !important;
+    left: 50% !important;
+    top: 50% !important;
+    transform: translate(-50%, -50%) !important;
+}

--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Js/nestedcontent.controllers.js
@@ -153,24 +153,7 @@ angular.module("umbraco").controller("Our.Umbraco.NestedContent.Controllers.Nest
                 return;
             }
 
-            // Position off screen till we are visible and can calculate offset
-            $scope.overlayMenu.style.top = -1000;
-            $scope.overlayMenu.style.left = -1000;
-
             $scope.overlayMenu.show = true;
-
-            $timeout(function () {
-
-                var wrapper = $("#contentwrapper");
-                var el = $("#nested-content--" + $scope.model.id + " .nested-content__node-type-picker .cell-tools-menu");
-
-                var offset = el.offsetRelative("#contentwrapper");
-
-                $scope.overlayMenu.style.top = (Math.round(wrapper.height() / 2) + offset.top) - Math.round(el.height() / 2);
-                $scope.overlayMenu.style.left = (Math.round(wrapper.width() / 2) + offset.left) - Math.round(el.width() / 2);
-
-            });
-
         };
 
         $scope.closeNodeTypePicker = function () {


### PR DESCRIPTION
* Removes code to position overlay menu through javascript.
* Adds CSS to position overlay menu in middle of window.