### PR TITLE
Fix grid - reorder bar obstructs fields

### DIFF
--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Css/nestedcontent.css
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Css/nestedcontent.css
@@ -206,3 +206,7 @@
     position: relative;
     transform: translate(-50%, -25%);
 }
+
+.nested-content__content .umb-editor-sub-header {
+    margin-top: 0px;
+}


### PR DESCRIPTION
If you have a grid element inside your nested content item the grid resize bar obstructs the field above. adding this style just removes the negative margin from the bar when inside a nested-content item. see https://our.umbraco.org/forum/using-umbraco-and-getting-started/88643-something-covering-textstring-property-in-nested-content