### PR TITLE
Fix margin-left on icons when using Lecoati.LeBlender package

### DIFF
--- a/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Css/nestedcontent.css
+++ b/src/Our.Umbraco.NestedContent/Web/UI/App_Plugins/NestedContent/Css/nestedcontent.css
@@ -210,3 +210,7 @@
 .nested-content__content .umb-editor-sub-header {
     margin-top: 0px;
 }
+
+.nested-content i {
+    margin-left: 0 !important;
+}


### PR DESCRIPTION
The Lecoati.LeBlender package adds a margin-left to icons so the nested content icon styles become quite ugly when you're using them together, this fixed it for me.

See screenshot of LeBlender control with Nested Content here:
http://ingolfsvaka.is/images/nestedcontent-leblender.PNG